### PR TITLE
Tk multiple heat acceptors

### DIFF
--- a/src/main/java/tekcays_addon/api/capability/IHeatContainer.java
+++ b/src/main/java/tekcays_addon/api/capability/IHeatContainer.java
@@ -32,7 +32,7 @@ public interface IHeatContainer {
     void setTemperature(int temperature);
 
     /**
-     * Change the amount of heat in the container by a given amount.
+     * Change the amount of heat in the container by {@code ADDING} a given amount.
      * If the resulted heat is lower than zero, heat will be set to 0.
      * If the resulted heat is higher than {@code maxHeat}, heat will be set to {@code maxHeat}.
      * @param amount the amount to change by

--- a/src/main/java/tekcays_addon/api/capability/impl/HeatContainerList.java
+++ b/src/main/java/tekcays_addon/api/capability/impl/HeatContainerList.java
@@ -14,7 +14,9 @@ public class HeatContainerList implements IHeatContainer {
 
     @Override
     public int getMinHeat() {
-        return 0;
+        return heatContainerList.stream()
+                .mapToInt(IHeatContainer::getMinHeat)
+                .sum();
     }
 
     @Override

--- a/src/main/java/tekcays_addon/api/capability/impl/HeatContainerList.java
+++ b/src/main/java/tekcays_addon/api/capability/impl/HeatContainerList.java
@@ -37,28 +37,26 @@ public class HeatContainerList implements IHeatContainer {
         return lowestTemp;
     }
 
-    /*
+    @Override
+    public void changeHeat(int amount) {
+        if (amount >= this.getHeat()) {
+            setHeat(0);
+            return;
+        }
+        int heatToChange = amount / heatContainerList.size();
+        for (IHeatContainer heatContainer : heatContainerList) {
+            heatContainer.changeHeat(heatToChange);
+        }
+    }
+
     @Override
     public int getHeat() {
         return heatContainerList.stream()
                 .mapToInt(IHeatContainer::getHeat)
                 .sum();
     }
-     */
-    ////////////////////!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    //Works only for ONE heat container, code must be reworked if multiple heat containers per multiblocks must be handled
-    ////////////////////!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    @Override
-    public void changeHeat(int amount) {
-        heatContainerList.get(0).changeHeat(amount);
-    }
-
-    @Override
-    public int getHeat() {
-        return heatContainerList.get(0).getHeat();
-    }
-
+    //Only needs to check one as they all should have the same temperature
     @Override
     public int getTemperature() {
         return heatContainerList.get(0).getTemperature();
@@ -66,7 +64,9 @@ public class HeatContainerList implements IHeatContainer {
 
     @Override
     public void setHeat(int amount) {
-        heatContainerList.get(0).setHeat(amount);
+        for (IHeatContainer heatContainer : heatContainerList) {
+            heatContainer.setHeat(amount);
+        }
     }
 
     @Override

--- a/src/main/java/tekcays_addon/api/metatileentity/multiblock/HeatContainerNoEnergyMultiblockController.java
+++ b/src/main/java/tekcays_addon/api/metatileentity/multiblock/HeatContainerNoEnergyMultiblockController.java
@@ -32,7 +32,7 @@ public abstract class HeatContainerNoEnergyMultiblockController extends RecipeMa
     @Override
     public TraceabilityPredicate autoAbilities(boolean checkEnergyIn, boolean checkMaintenance, boolean checkItemIn, boolean checkItemOut, boolean checkFluidIn, boolean checkFluidOut, boolean checkMuffler) {
         TraceabilityPredicate predicate = super.autoAbilities(false, checkMaintenance, checkItemIn, checkItemOut, checkFluidIn, checkFluidOut, checkMuffler);
-        predicate = predicate.or(abilities(TKCYAMultiblockAbility.HEAT_CONTAINER).setMinGlobalLimited(1).setMaxGlobalLimited(1).setPreviewCount(1));
+        predicate = predicate.or(abilities(TKCYAMultiblockAbility.HEAT_CONTAINER));
         return predicate;
     }
 

--- a/src/main/java/tekcays_addon/api/metatileentity/multiblock/HeatContainerNoEnergyMultiblockController.java
+++ b/src/main/java/tekcays_addon/api/metatileentity/multiblock/HeatContainerNoEnergyMultiblockController.java
@@ -6,11 +6,8 @@ import gregtech.api.recipes.RecipeMap;
 import net.minecraft.util.ResourceLocation;
 import tekcays_addon.api.capability.IHeatContainer;
 import tekcays_addon.api.capability.IHeatMachine;
-import tekcays_addon.api.capability.impl.HeatContainer;
+import tekcays_addon.api.capability.impl.HeatContainerList;
 import tekcays_addon.api.capability.impl.HeatContainerNoEnergyMultiblockRecipeLogic;
-
-import java.util.List;
-
 
 public abstract class HeatContainerNoEnergyMultiblockController extends RecipeMapMultiblockController implements IHeatMachine {
 
@@ -24,12 +21,7 @@ public abstract class HeatContainerNoEnergyMultiblockController extends RecipeMa
     @Override
     protected void initializeAbilities() {
         super.initializeAbilities();
-        List<IHeatContainer> list = getAbilities(TKCYAMultiblockAbility.HEAT_CONTAINER);
-        if (list.isEmpty()) {
-            this.heatContainer = new HeatContainer(this, 0, 2000000);
-        } else {
-            this.heatContainer = list.get(0);
-        }
+        this.heatContainer = new HeatContainerList(getAbilities(TKCYAMultiblockAbility.HEAT_CONTAINER));
     }
 
     @Override
@@ -48,4 +40,5 @@ public abstract class HeatContainerNoEnergyMultiblockController extends RecipeMa
     public IHeatContainer getHeatContainer() {
         return this.heatContainer;
     }
+
 }

--- a/src/main/java/tekcays_addon/common/metatileentities/multi/MetaTileEntityAdvancedBlastFurnace.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/multi/MetaTileEntityAdvancedBlastFurnace.java
@@ -206,14 +206,14 @@ public class MetaTileEntityAdvancedBlastFurnace extends HeatContainerNoEnergyMul
     @Override
     protected BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start(RIGHT, FRONT, UP)
-                .aisle("#HHH#", "HHHHH", "HHHHH", "HHHHH", "#HHH#")
-                .aisle("#CCC#", "CCCCC", "CCCCC", "CCCCC", "#CCC#")
-                .aisle("#YYY#", "YYYYY", "XYYYX", "YYYYY", "#YYY#")
-                .aisle("#YSY#", "Y###Y", "Y###Y", "Y###Y", "#YMY#")
-                .aisle("#YYY#", "Y###Y", "Y#P#Y", "Y###Y", "#YYY#").setRepeatable(1, 11)
-                .aisle("#YYY#", "YOOOY", "YOUOY", "YOOOY", "#YYY#")
+                .aisle("AHHHA", "HHHHH", "HHHHH", "HHHHH", "AHHHA")
+                .aisle("ACCCA", "CCCCC", "CCCCC", "CCCCC", "ACCCA")
+                //.aisle("AYYYA", "YYYYY", "XYYYX", "YYYYY", "AYYYA")
+                .aisle("AYSYA", "Y###Y", "Y###Y", "Y###Y", "AYMYA")
+                .aisle("ACCCA", "C###C", "C#P#C", "C###C", "ACCCA").setRepeatable(1, 11)
+                .aisle("AYYYA", "YOOOY", "YOUOY", "YOOOY", "AYYYA")
                 .where('S', selfPredicate())
-                .where('H', abilities(TKCYAMultiblockAbility.HEAT_CONTAINER).setMinGlobalLimited(1).setMaxGlobalLimited(1).setPreviewCount(1).or(states(getCasingState())))
+                .where('H', abilities(TKCYAMultiblockAbility.HEAT_CONTAINER))
                 .where('C', heatingCoils())
                 .where('Y', states(getCasingState()))
                 .where('X', states(getCasingState())
@@ -226,6 +226,7 @@ public class MetaTileEntityAdvancedBlastFurnace extends HeatContainerNoEnergyMul
                 .where('M', abilities(MultiblockAbility.MAINTENANCE_HATCH))
                 .where('U', abilities(MultiblockAbility.MUFFLER_HATCH))
                 .where('#', air())
+                .where('A', any())
                 .build();
     }
 

--- a/src/main/java/tekcays_addon/common/metatileentities/multiblockpart/MetaTileEntityHeatAcceptor.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/multiblockpart/MetaTileEntityHeatAcceptor.java
@@ -38,10 +38,11 @@ public class MetaTileEntityHeatAcceptor extends MetaTileEntityMultiblockPart imp
 
     private final IHeatContainer heatContainer;
     private final int coolingRate = 10 * getTier() * getTier();
+    private final int heatCapacity = getTier() * getTier() * 20000;
 
     public MetaTileEntityHeatAcceptor(@Nonnull ResourceLocation metaTileEntityId, int tier) {
         super(metaTileEntityId, tier);
-        this.heatContainer = new HeatContainer(this, 0, getTier() * getTier() * 20000);
+        this.heatContainer = new HeatContainer(this, 0, heatCapacity);
     }
 
     @Override
@@ -85,6 +86,7 @@ public class MetaTileEntityHeatAcceptor extends MetaTileEntityMultiblockPart imp
         super.addInformation(stack, player, tooltip, advanced);
         tooltip.add(I18n.format("tkcya.machine.heat_acceptor.tooltip.1"));
         tooltip.add(I18n.format("tkcya.machine.heat_acceptor.tooltip.2", coolingRate));
+        tooltip.add(I18n.format("tkcya.machine.heat_acceptor.tooltip.3", heatCapacity / 1000));
     }
 
     @Override

--- a/src/main/resources/assets/tkcya/lang/en_us.lang
+++ b/src/main/resources/assets/tkcya/lang/en_us.lang
@@ -402,6 +402,7 @@ tkcya.machine.spiral_separator.tooltip.1=Run §a1§7 parallel recipe per §a2§7
 #Heat acceptors
 tkcya.machine.heat_acceptor.tooltip.1=Accepts §cHEAT§7 on §eANY§7 side.
 tkcya.machine.heat_acceptor.tooltip.2=Loses §c%d HU/s§7.
+tkcya.machine.heat_acceptor.tooltip.3=Capacity: §c%dk HU§7.
 
 tekcays_addon.multiblock.electric_melter.tooltip.1=Temperature: §a%d K§7.
 tekcays_addon.multiblock.electric_melter.tooltip.2=Not enough energy can be input to reach the target!


### PR DESCRIPTION
This PR allows multiblocks to contain and handle multiple HeatContainers. Also tweaks the Advanced Blast Furnace, and adds the heat capacity of Heat Acceptors in its tooltip.