### PR TITLE
Tk temp detector select temp

### DIFF
--- a/src/main/java/tekcays_addon/common/covers/CoverDetectorTemperature.java
+++ b/src/main/java/tekcays_addon/common/covers/CoverDetectorTemperature.java
@@ -6,20 +6,28 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.cover.CoverBehavior;
+import gregtech.api.cover.CoverWithUI;
 import gregtech.api.cover.ICoverable;
-import gregtech.client.renderer.texture.Textures;
+import gregtech.api.gui.GuiTextures;
+import gregtech.api.gui.ModularUI;
+import gregtech.api.gui.widgets.*;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.*;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.TextComponentTranslation;
-import tekcays_addon.api.capability.IHeatContainer;
+import net.minecraft.util.text.TextFormatting;
 import tekcays_addon.api.capability.TKCYATileCapabilities;
 import tekcays_addon.api.render.TKCYATextures;
 
-public class CoverDetectorTemperature extends CoverBehavior implements ITickable {
+
+public class CoverDetectorTemperature extends CoverBehavior implements ITickable, CoverWithUI {
 
     private boolean isInverted;
+    private int temperatureThreshold;
+    private final int MAX_TEMPERATURE = 10_000;
 
     public CoverDetectorTemperature(ICoverable coverHolder, EnumFacing attachedSide) {
         super(coverHolder, attachedSide);
@@ -36,11 +44,8 @@ public class CoverDetectorTemperature extends CoverBehavior implements ITickable
         TKCYATextures.DETECTOR_TEMPERATURE.renderSided(attachedSide, plateBox, renderState, pipeline, translation);
     }
 
-    @Override
-    public EnumActionResult onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
-        if (this.coverHolder.getWorld().isRemote) {
-            return EnumActionResult.SUCCESS;
-        }
+
+    public void onScrewdriverSneakClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
 
         if (this.isInverted) {
             this.setInverted();
@@ -49,7 +54,67 @@ public class CoverDetectorTemperature extends CoverBehavior implements ITickable
             this.setInverted();
             playerIn.sendMessage(new TextComponentTranslation("tkcya.cover.temperature_detector.message_temperature_storage_inverted"));
         }
+    }
+
+    @Override
+    public EnumActionResult onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
+
+        if (!coverHolder.getWorld().isRemote) {
+            if (playerIn.isSneaking()) {
+                onScrewdriverSneakClick(playerIn, hand, hitResult);
+                return EnumActionResult.SUCCESS;
+            } else openUI((EntityPlayerMP) playerIn);
+        }
         return EnumActionResult.SUCCESS;
+    }
+
+    private void adjustTemperatureThreshold(int amount) {
+        setTemperatureThreshold(MathHelper.clamp(temperatureThreshold + amount, 1, MAX_TEMPERATURE));
+    }
+
+    private void setTemperatureThreshold(int temperatureThreshold) {
+        this.temperatureThreshold = temperatureThreshold;
+        coverHolder.markDirty();
+    }
+
+    protected String getUITitle() {
+        return "Temperature Detector";
+    }
+
+    protected ModularUI buildUI(ModularUI.Builder builder, EntityPlayer player) {
+        return builder.build(this, player);
+    }
+
+    @Override
+    public ModularUI createUI(EntityPlayer player) {
+        WidgetGroup primaryGroup = new WidgetGroup();
+        primaryGroup.addWidget(new LabelWidget(10, 5, getUITitle()));
+
+        primaryGroup.addWidget(new ImageWidget(44, 20, 62, 20, GuiTextures.DISPLAY));
+
+        primaryGroup.addWidget(new IncrementButtonWidget(136, 20, 30, 20, 1, 10, 100, 1000, this::adjustTemperatureThreshold)
+                .setDefaultTooltip()
+                .setShouldClientCallback(false));
+        primaryGroup.addWidget(new IncrementButtonWidget(10, 20, 34, 20, -1, -10, -100, -1000, this::adjustTemperatureThreshold)
+                .setDefaultTooltip()
+                .setShouldClientCallback(false));
+
+        TextFieldWidget2 textFieldWidget = new TextFieldWidget2(45, 26, 60, 20, () -> Integer.toString(temperatureThreshold), val -> setTemperatureThreshold(Integer.parseInt(val)))
+                .setCentered(true)
+                .setNumbersOnly(1, MAX_TEMPERATURE)
+                .setMaxLength(5);
+        primaryGroup.addWidget(textFieldWidget);
+
+        //Prints Kelvin symbol
+        primaryGroup.addWidget(new LabelWidget(115, 26, "K", TextFormatting.BLACK));
+
+        //Prints the current temperature of the HeatContainer
+        primaryGroup.addWidget(new LabelWidget(15, 46, String.format("Current temperature: %d K", getHeatContainerTemperature()), TextFormatting.BLACK));
+
+        ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 184 + 82)
+                .widget(primaryGroup)
+                .bindPlayerInventory(player.inventory, GuiTextures.SLOT, 7, 184);
+        return buildUI(builder, player);
     }
 
     private void setInverted() {
@@ -61,27 +126,26 @@ public class CoverDetectorTemperature extends CoverBehavior implements ITickable
         }
     }
 
+    private int getHeatContainerTemperature() {
+        return coverHolder.getCapability(TKCYATileCapabilities.CAPABILITY_HEAT_CONTAINER, EnumFacing.DOWN).getTemperature();
+    }
+
     @Override
     public void update() {
-        if (this.coverHolder.getOffsetTimer() % 20 != 0)
-            return;
 
-        IHeatContainer heatContainer = coverHolder.getCapability(TKCYATileCapabilities.CAPABILITY_HEAT_CONTAINER, null);
-        if (heatContainer != null) {
-            long currentTemperature = heatContainer.getTemperature();
-            long maxTemperature = heatContainer.getMaxTemperature();
+        int currentTemp = getHeatContainerTemperature();
+        if (currentTemp == 0) return;
 
-            if (maxTemperature == 0)
-                return;
-
-            int outputAmount = (int) (15.0 * currentTemperature / maxTemperature);
-
-            if (this.isInverted)
-                outputAmount = 15 - outputAmount;
-
-            setRedstoneSignalOutput(outputAmount);
+        if (!isInverted) {
+            if (currentTemp > temperatureThreshold) setRedstoneSignalOutput(15);
+            else setRedstoneSignalOutput(0);
+        } else {
+            if (currentTemp > temperatureThreshold) setRedstoneSignalOutput(0);
+            else setRedstoneSignalOutput(15);
         }
     }
+
+
 
     @Override
     public boolean canConnectRedstone() {
@@ -92,21 +156,25 @@ public class CoverDetectorTemperature extends CoverBehavior implements ITickable
     public void writeToNBT(NBTTagCompound tagCompound) {
         super.writeToNBT(tagCompound);
         tagCompound.setBoolean("isInverted", this.isInverted);
+        tagCompound.setInteger("temperatureThreshold", this.temperatureThreshold);
     }
 
     @Override
     public void readFromNBT(NBTTagCompound tagCompound) {
         super.readFromNBT(tagCompound);
         this.isInverted = tagCompound.getBoolean("isInverted");
+        this.temperatureThreshold = tagCompound.getInteger("temperatureThreshold");
     }
 
     @Override
     public void writeInitialSyncData(PacketBuffer packetBuffer) {
         packetBuffer.writeBoolean(this.isInverted);
+        packetBuffer.writeInt(this.temperatureThreshold);
     }
 
     @Override
     public void readInitialSyncData(PacketBuffer packetBuffer) {
         this.isInverted = packetBuffer.readBoolean();
+        this.temperatureThreshold = packetBuffer.readInt();
     }
 }

--- a/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntitySingleCrucible.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntitySingleCrucible.java
@@ -202,7 +202,7 @@ public class MetaTileEntitySingleCrucible extends MetaTileEntity implements IDat
         currentHeat = heatContainer.getHeat();
         pushFluidsIntoNearbyHandlers(getFrontFacing());
 
-        //Loses heat over time if no more heat heat is provided
+        //Loses heat over time if no more heat is provided
         if (getOffsetTimer() % 20 == 0) {
             if (previousHeat == currentHeat && currentTemp > GCYSValues.EARTH_TEMPERATURE) {
                 heatContainer.changeHeat(HEAT_COOL);

--- a/src/main/resources/assets/tkcya/lang/en_us.lang
+++ b/src/main/resources/assets/tkcya/lang/en_us.lang
@@ -493,6 +493,10 @@ tkcya.electric_cooler.tooltip.3=Outputs §c%d HU/t§7 on the §eBACK§7 face.
 tkcya.cover.temperature_detector.message_temperature_storage_normal=Monitoring Normal Temperature Storage
 tkcya.cover.temperature_detector.message_temperature_storage_inverted=Monitoring Inverted Temperature Storage
 
+##Buttons in covers
+cover.cover.detector.inverted=I
+cover.cover.detector.normal=N
+
 #Tricorder
 behavior.tricorder.current_heat=Current Heat: %s HU
 behavior.tricorder.min_heat=Minimum Heat: %s HU

--- a/src/main/resources/assets/tkcya/lang/en_us.lang
+++ b/src/main/resources/assets/tkcya/lang/en_us.lang
@@ -324,8 +324,8 @@ metaitem.electrode.name=%s Electrode
 metaitem.electrode.tooltip=For electrolysis
 metaitem.filter.name=%s Filter
 metaitem.filter.tooltip=For filtration duh
-metaitem.cover.temperature_detector.name=Cover Temperature Detector
-metaitem.cover.temperature.detector.tooltip=Gives out Temperature as Redstone (as Cover)
+metaitem.cover_temperature_detector.name=Cover Temperature Detector
+metaitem.cover.temperature.detector.tooltip=Emits a redstone signal if the temperature exceeds a specified value (as Cover). Right click with a Screwdriver while sneaking to invert redstone signal.
 
 item.mica_pulp.dust=Mica Based Pulp
 


### PR DESCRIPTION
This PR modifies the temperature detector to be used slightly like in GT6 for the logic, and like a pump in GTCEu for the GUI. 
The player can open a GUI by right-clicking with a screwdriver and select a temperature threshold to emit a redstone signal if the IHeatContainer temperature exceeds that value. 
The signal emission can be reverted by right-clicking with a screwdriver while sneaking.