### PR TITLE
Tk fuel heaters stop by block

### DIFF
--- a/src/main/java/tekcays_addon/api/metatileentity/FuelHeater.java
+++ b/src/main/java/tekcays_addon/api/metatileentity/FuelHeater.java
@@ -187,6 +187,9 @@ public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProv
             }
             return true;
         } else {
+
+            if (facing != getFrontFacing()) return false;
+
             ItemStack itemInHand = playerIn.getHeldItemMainhand();
             if (playerIn.isSneaking() && itemInHand.getItem().equals(Items.STICK)) {
                 Random rand = new Random();

--- a/src/main/java/tekcays_addon/api/metatileentity/FuelHeater.java
+++ b/src/main/java/tekcays_addon/api/metatileentity/FuelHeater.java
@@ -13,6 +13,7 @@ import gregtech.api.sound.GTSounds;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -20,6 +21,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
@@ -43,7 +45,7 @@ import java.util.List;
 import static gregtech.api.capability.GregtechDataCodes.IS_WORKING;
 import static net.minecraft.util.EnumFacing.*;
 
-public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProvider, IActiveOutputSide{
+public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProvider, IActiveOutputSide, IFreeFace{
 
     protected int heatIncreaseRate;
     protected HeatContainer heatContainer;
@@ -99,20 +101,24 @@ public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProv
     @Override
     public void update() {
         super.update();
-        if (burnTimeLeft <= 0) {
-            setBurning(false);
-            tryConsumeNewFuel();
-        }
-        if (burnTimeLeft > 0) {
-            setBurning(true);
-            int currentHeat = heatContainer.getHeat();
-            if (!getWorld().isRemote) {
-                if (currentHeat + heatIncreaseRate < heatContainer.getMaxHeat())
-                    heatContainer.setHeat(currentHeat + heatIncreaseRate);
-                transferHeat(heatIncreaseRate);
+
+        if (!this.checkFaceFree(getPos(), getFrontFacing())) setBurning(false);
+        else {
+            if (burnTimeLeft <= 0) {
+                setBurning(false);
+                tryConsumeNewFuel();
             }
-            burnTimeLeft -= 1;
-            markDirty();
+            if (burnTimeLeft > 0) {
+                setBurning(true);
+                int currentHeat = heatContainer.getHeat();
+                if (!getWorld().isRemote) {
+                    if (currentHeat + heatIncreaseRate < heatContainer.getMaxHeat())
+                        heatContainer.setHeat(currentHeat + heatIncreaseRate);
+                    transferHeat(heatIncreaseRate);
+                }
+                burnTimeLeft -= 1;
+                markDirty();
+            }
         }
     }
 

--- a/src/main/java/tekcays_addon/api/metatileentity/FuelHeater.java
+++ b/src/main/java/tekcays_addon/api/metatileentity/FuelHeater.java
@@ -38,7 +38,6 @@ import tekcays_addon.api.capability.TKCYATileCapabilities;
 import tekcays_addon.api.capability.impl.HeatContainer;
 import tekcays_addon.api.render.TKCYATextures;
 import tekcays_addon.api.utils.FuelHeaterTiers;
-import tekcays_addon.api.utils.TKCYALog;
 import tekcays_addon.common.blocks.blocks.BlockBrick;
 
 import javax.annotation.Nonnull;
@@ -53,11 +52,11 @@ public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProv
 
     protected int heatIncreaseRate;
     protected HeatContainer heatContainer;
-    protected boolean isBurning;
+    private boolean isBurning;
     protected final FuelHeaterTiers fuelHeater;
     private final float efficiency;
     private final int powerMultiplier;
-    protected int burnTimeLeft;
+    private int burnTimeLeft;
     private boolean canIgnite;
     private final int IGNITION_CHANCE_WOOD_STICK = 30;
 
@@ -100,10 +99,7 @@ public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProv
 
     protected void setBurnTimeLeft(int amount) {
         this.burnTimeLeft =  amount;
-        //if (!getWorld().isRemote) markDirty();
     }
-
-
 
     private void setIgnition() {
         canIgnite = true;
@@ -228,13 +224,10 @@ public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProv
 
     public void setBurning(boolean burning) {
         this.isBurning = burning;
-        /*
         if (!getWorld().isRemote) {
             markDirty();
             writeCustomData(IS_WORKING, buf -> buf.writeBoolean(burning));
         }
-
-         */
     }
 
     @Override
@@ -281,7 +274,6 @@ public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProv
         this.burnTimeLeft = buf.readInt();
     }
 
-    /*
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
@@ -290,9 +282,6 @@ public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProv
             scheduleRenderUpdate();
         }
     }
-
-     */
-
 
     @Override
     public SoundEvent getSound() {

--- a/src/main/java/tekcays_addon/api/metatileentity/FuelHeater.java
+++ b/src/main/java/tekcays_addon/api/metatileentity/FuelHeater.java
@@ -194,6 +194,7 @@ public abstract class FuelHeater extends MetaTileEntity implements IDataInfoProv
         tooltip.add(I18n.format("tkcya.heater.tooltip.2", heatIncreaseRate));
         tooltip.add(I18n.format("tkcya.machine.energy_conversion_efficiency",  TextFormatting.WHITE + String.format("%.02f", efficiency * 100.00F) + "%"));
         tooltip.add(I18n.format("tkcya.machine.free_front_face.tooltip"));
+        tooltip.add(I18n.format("tkcya.machine.fuel_heater.ignition.tooltip", TextFormatting.WHITE + String.format("%d%%", IGNITION_CHANCE_WOOD_STICK)));
     }
 
     @Override

--- a/src/main/java/tekcays_addon/api/metatileentity/IFreeFace.java
+++ b/src/main/java/tekcays_addon/api/metatileentity/IFreeFace.java
@@ -1,0 +1,27 @@
+package tekcays_addon.api.metatileentity;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+
+import static codechicken.lib.util.ClientUtils.getWorld;
+
+public interface IFreeFace {
+
+    /**
+     * Checks if a {@code MetaTileEntity} has {@code Air} in the block adjacent to its face.
+     * @param pos the position of the {@code MetaTileEntity}
+     * @param facing the side of the {@code MetaTileEntity} to consider
+     * @return
+     */
+    default boolean checkFaceFree(BlockPos pos, EnumFacing facing) {
+        BlockPos position = pos.offset(facing);
+        try {
+            IBlockState blockState = getWorld().getBlockState(position);
+            return blockState.getBlock().isAir(blockState, getWorld(), position);
+        } catch (NullPointerException e) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/tekcays_addon/api/metatileentity/IFreeFace.java
+++ b/src/main/java/tekcays_addon/api/metatileentity/IFreeFace.java
@@ -1,8 +1,11 @@
 package tekcays_addon.api.metatileentity;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import tekcays_addon.api.utils.TKCYALog;
 
 import static codechicken.lib.util.ClientUtils.getWorld;
 
@@ -20,8 +23,7 @@ public interface IFreeFace {
             IBlockState blockState = getWorld().getBlockState(position);
             return blockState.getBlock().isAir(blockState, getWorld(), position);
         } catch (NullPointerException e) {
-            return false;
+            return true;
         }
     }
-
 }

--- a/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityElectricHeater.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityElectricHeater.java
@@ -5,8 +5,6 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.ColourMultiplier;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
-import com.google.common.base.Preconditions;
-import gregicality.science.api.utils.NumberFormattingUtil;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IActiveOutputSide;
@@ -37,7 +35,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
-import static gregtech.api.capability.GregtechDataCodes.UPDATE_FRONT_FACING;
 import static net.minecraft.util.EnumFacing.*;
 import static tekcays_addon.api.utils.TKCYAValues.EU_TO_HU;
 

--- a/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityFluidizedHeater.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityFluidizedHeater.java
@@ -107,8 +107,6 @@ public class MetaTileEntityFluidizedHeater extends FuelHeater implements IDataIn
         TKCYATextures.FLUIDIZED_FUEL_HEATER.renderOrientedState(renderState, translation, pipeline, getFrontFacing(), isBurning(), true);
     }
 
-
-
     private boolean isThereCoke() {
         return importItems.getStackInSlot(0).getItem().equals(SOLID_FUEL);
     }
@@ -129,39 +127,5 @@ public class MetaTileEntityFluidizedHeater extends FuelHeater implements IDataIn
         super.addInformation(stack, player, tooltip, advanced);
     }
 
-    @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound data) {
-        super.writeToNBT(data);
-        data.setInteger("BurnTimeLeft", burnTimeLeft);
-        return data;
-    }
-
-    @Override
-    public void readFromNBT(NBTTagCompound data) {
-        super.readFromNBT(data);
-        this.burnTimeLeft= data.getInteger("BurnTimeLeft");
-        this.isBurning = burnTimeLeft > 0;
-    }
-
-    @Override
-    public void writeInitialSyncData(PacketBuffer buf) {
-        super.writeInitialSyncData(buf);
-        buf.writeBoolean(isBurning);
-    }
-
-    @Override
-    public void receiveInitialSyncData(PacketBuffer buf) {
-        super.receiveInitialSyncData(buf);
-        this.isBurning = buf.readBoolean();
-    }
-
-    @Override
-    public void receiveCustomData(int dataId, PacketBuffer buf) {
-        super.receiveCustomData(dataId, buf);
-        if (dataId == IS_WORKING) {
-            this.isBurning = buf.readBoolean();
-            scheduleRenderUpdate();
-        }
-    }
 
 }

--- a/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityFluidizedHeater.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityFluidizedHeater.java
@@ -127,5 +127,4 @@ public class MetaTileEntityFluidizedHeater extends FuelHeater implements IDataIn
         super.addInformation(stack, player, tooltip, advanced);
     }
 
-
 }

--- a/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityGasHeater.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityGasHeater.java
@@ -132,39 +132,4 @@ public class MetaTileEntityGasHeater extends FuelHeater implements IDataInfoProv
         super.addInformation(stack, player, tooltip, advanced);
     }
 
-    @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound data) {
-        super.writeToNBT(data);
-        data.setInteger("BurnTimeLeft", burnTimeLeft);
-        return data;
-    }
-
-    @Override
-    public void readFromNBT(NBTTagCompound data) {
-        super.readFromNBT(data);
-        this.burnTimeLeft= data.getInteger("BurnTimeLeft");
-        this.isBurning = burnTimeLeft > 0;
-    }
-
-    @Override
-    public void writeInitialSyncData(PacketBuffer buf) {
-        super.writeInitialSyncData(buf);
-        buf.writeBoolean(isBurning);
-    }
-
-    @Override
-    public void receiveInitialSyncData(PacketBuffer buf) {
-        super.receiveInitialSyncData(buf);
-        this.isBurning = buf.readBoolean();
-    }
-
-    @Override
-    public void receiveCustomData(int dataId, PacketBuffer buf) {
-        super.receiveCustomData(dataId, buf);
-        if (dataId == IS_WORKING) {
-            this.isBurning = buf.readBoolean();
-            scheduleRenderUpdate();
-        }
-    }
-
 }

--- a/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityLiquidFuelHeater.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityLiquidFuelHeater.java
@@ -103,39 +103,5 @@ public class MetaTileEntityLiquidFuelHeater extends FuelHeater implements IDataI
         super.addInformation(stack, player, tooltip, advanced);
     }
 
-    @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound data) {
-        super.writeToNBT(data);
-        data.setInteger("BurnTimeLeft", burnTimeLeft);
-        return data;
-    }
-
-    @Override
-    public void readFromNBT(NBTTagCompound data) {
-        super.readFromNBT(data);
-        this.burnTimeLeft= data.getInteger("BurnTimeLeft");
-        this.isBurning = burnTimeLeft > 0;
-    }
-
-    @Override
-    public void writeInitialSyncData(PacketBuffer buf) {
-        super.writeInitialSyncData(buf);
-        buf.writeBoolean(isBurning);
-    }
-
-    @Override
-    public void receiveInitialSyncData(PacketBuffer buf) {
-        super.receiveInitialSyncData(buf);
-        this.isBurning = buf.readBoolean();
-    }
-
-    @Override
-    public void receiveCustomData(int dataId, PacketBuffer buf) {
-        super.receiveCustomData(dataId, buf);
-        if (dataId == IS_WORKING) {
-            this.isBurning = buf.readBoolean();
-            scheduleRenderUpdate();
-        }
-    }
 
 }

--- a/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityLiquidFuelHeater.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntityLiquidFuelHeater.java
@@ -96,7 +96,6 @@ public class MetaTileEntityLiquidFuelHeater extends FuelHeater implements IDataI
         setBurnTimeLeft(getBurnTime(CREOSOTE, fuelHeater));
     }
 
-
     @Override
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("tkcya.machine.liquid_fuel_heater.tooltip"));

--- a/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntitySolidFuelHeater.java
+++ b/src/main/java/tekcays_addon/common/metatileentities/single/MetaTileEntitySolidFuelHeater.java
@@ -28,6 +28,7 @@ import tekcays_addon.api.capability.impl.HeatContainer;
 import tekcays_addon.api.metatileentity.FuelHeater;
 import tekcays_addon.api.render.TKCYATextures;
 import tekcays_addon.api.utils.FuelHeaterTiers;
+import tekcays_addon.api.utils.TKCYALog;
 import tekcays_addon.common.blocks.blocks.BlockBrick;
 
 import javax.annotation.Nullable;
@@ -117,6 +118,7 @@ public class MetaTileEntitySolidFuelHeater extends FuelHeater implements IDataIn
         }
         setBurnTimeLeft(burnTime);
     }
+
     @Override
     @SideOnly(Side.CLIENT)
     protected SimpleOverlayRenderer getBaseRenderer() {
@@ -153,7 +155,6 @@ public class MetaTileEntitySolidFuelHeater extends FuelHeater implements IDataIn
         super.readFromNBT(data);
         this.containerInventory.deserializeNBT(data.getCompoundTag("ContainerInventory"));
     }
-
 
     @Override
     public boolean isAutoOutputItems() {

--- a/src/main/resources/assets/tkcya/lang/en_us.lang
+++ b/src/main/resources/assets/tkcya/lang/en_us.lang
@@ -506,6 +506,8 @@ behavior.tricorder.max_heat=Maximum Heat: %s HU
 behavior.tricorder.burn_time_left= Burn Time Left %s ticks
 behavior.tricorder.currentTemp=Current Temp: %s K
 behavior.tricorder.heatMultiplier=Heat Multiplier: %d
+behavior.tricorder.can_ignite=Can ignite: %s
+behavior.tricorder.is_burning=Is burning: %s
 
 
 # Errors

--- a/src/main/resources/assets/tkcya/lang/en_us.lang
+++ b/src/main/resources/assets/tkcya/lang/en_us.lang
@@ -382,6 +382,7 @@ tkcya.steam_air_compressor.tooltip.2=Consumes %sL of Steam per second.
 tkcya.machine.no_overclock.tooltip=No overclock
 tkcya.machine.height.tooltip=Height: %d
 tkcya.machine.redstone.inverse.tooltip=Can be stopped with a redstone signal.
+tkcya.machine.free_front_face.tooltip=The front face must be free.
 tkcya.machine.energy_conversion_efficiency=§eEfficency:§7 %s
 tkcya.machine.pressure_decrease.tooltip=Decreases the pressure by §b%sPa§7 per second while running.
 tkcya.machine.pressure_increase.tooltip=Increases the pressure by §b%sPa§7 per second while running.

--- a/src/main/resources/assets/tkcya/lang/en_us.lang
+++ b/src/main/resources/assets/tkcya/lang/en_us.lang
@@ -483,6 +483,7 @@ tkcya.max_parallel.tooltip=Max Parallel: §e%s§7
 #Heaters
 tkcya.heater.tooltip.1=For heating.
 tkcya.heater.tooltip.2=Outputs §c%s HU/t§7 on the §eTOP§7 side.
+tkcya.machine.fuel_heater.ignition.tooltip=Ignition by right-clicking on the §eFRONT§7 side with wood sticks while sneaking (%s chance).
 tkcya.electric_heater.tooltip.1=Outputs §c%s HU/t§7 on the §eFRONT§7 side.
 
 #Electric Cooler


### PR DESCRIPTION
This PR tries to mimic a bit GT6's burning boxes behavior and also to fix rendering issues.

- FuelHeaters now have to be ignited by right-clicking the front face while sneaking with wood sticks in hand (30% chance)
- FuelHeaters requires the block adjacent to its front face to be Air to be able to burn fuel. This can be used to stop burning via a piston.